### PR TITLE
Refactor VPC Terraform module

### DIFF
--- a/vpc/data.tf
+++ b/vpc/data.tf
@@ -1,20 +1,6 @@
 # This data source retrieves information about the available Availability Zones
-# within the specified AWS region (e.g us-west-2).
+# within the specified AWS region. We only want to work with zones in an
+# 'available' state.
 data "aws_availability_zones" "this" {
   state = "available"
-}
-
-# This data source retrieves information about a specific prefix list in AWS. A
-# prefix list is a set of CIDR blocks that are used to simplify the setup of
-# security groups and route tables. In this case, it is getting the prefix list
-# associated with the Amazon S3 service.
-data "aws_prefix_list" "this" {
-  name = format("com.amazonaws.%s.s3", var.aws_region)
-}
-
-data "aws_subnets" "private" {
-  filter {
-    name   = "tag:Name"
-    values = [format("%s-private*", var.vpc_name)]
-  }
 }

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -1,17 +1,11 @@
-output "availability_zones" {
-  value = data.aws_availability_zones.this.names
-}
-
-# This output resource produces a list of identifiers for all the private
-# subnets retrieved by the 'aws_subnets.private' data source. This output
-# resource facilitate the creation of extra VPC Service Endpoints within the
-# root module.
+# This output resource allows you to provision extra VPC Service Endpoints from
+# the root module.
 output "private_subnets" {
-  value = data.aws_subnets.private.ids
+  value = [for subnet in aws_subnet.private : subnet.id]
 }
 
-# This output resource facilitate the creation of extra VPC Service Endpoints
-# within the root module.
+# This output resource allows you to provision extra VPC Service Endpoints from
+# the root module.
 output "vpc_id" {
   value = aws_vpc.this.id
 }


### PR DESCRIPTION
- Update Availability Zones data source to only consider 'available' zones.
- Remove prefix list and private subnets data sources.
- Refactor conditional logic for private and public subnets, renaming `is_private_cidr_list_empty` and `is_public_cidr_list_empty` to `one_or_more_private_subnets` and `one_or_more_public_subnets` respectively, for clarity.
- Adjust VPC resources' count logic to align with new conditionals.
- Update outputs to simplify provisioning of additional VPC Service Endpoints.